### PR TITLE
Fix publish_dir name and update gh-pages actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,9 +5,9 @@ name: Java CI with Maven
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main-test ]
   pull_request:
-    branches: [ main ]
+    branches: [ main-test ]
 
 jobs:
   build:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,7 +2,8 @@ name: Generate and publish API JavaDocs
 on:
   push:
     branches:
-      - main
+      - main-test
+  workflow_dispatch:
 
 jobs:
   docs:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -26,7 +26,7 @@ jobs:
       run: mvn javadoc:javadoc
 
     - name: Deploy docs
-      uses: peaceiris/actions-gh-pages@v3
+      uses: peaceiris/actions-gh-pages@v4
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
-        publish_dir: ./target/report/apidocs
+        publish_dir: ./target/reports/apidocs

--- a/pom.xml
+++ b/pom.xml
@@ -87,6 +87,7 @@
 						<artifactId>maven-javadoc-plugin</artifactId>
 						<version>3.5.0</version>
 						<configuration>
+							<source>11</source>
 							<quiet>true</quiet>
 							<notimestamp>true</notimestamp>
 							<doclint>all,-missing</doclint>

--- a/pom.xml
+++ b/pom.xml
@@ -244,8 +244,8 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>3.11.0</version>
 				<configuration>
-					<source>1.8</source>
-					<target>1.8</target>
+					<source>9</source>
+					<target>9</target>
 					<encoding>${project.build.sourceEncoding}</encoding>
 					<showDeprecation>true</showDeprecation>
 					<showWarnings>true</showWarnings>

--- a/pom.xml
+++ b/pom.xml
@@ -107,7 +107,7 @@
 					<plugin>
 		      			<groupId>org.apache.maven.plugins</groupId>
 		      			<artifactId>maven-gpg-plugin</artifactId>
-		      			<version>1.6</version>
+		      			<version>3.2</version>
 		      			<executions>
 		        			<execution>
 		          				<id>sign-artifacts</id>
@@ -242,7 +242,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
-				<version>3.11.0</version>
+				<version>3.13.0</version>
 				<configuration>
 					<source>1.8</source>
 					<target>1.8</target>

--- a/pom.xml
+++ b/pom.xml
@@ -244,8 +244,8 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>3.11.0</version>
 				<configuration>
-					<source>9</source>
-					<target>9</target>
+					<source>1.8</source>
+					<target>1.8</target>
 					<encoding>${project.build.sourceEncoding}</encoding>
 					<showDeprecation>true</showDeprecation>
 					<showWarnings>true</showWarnings>


### PR DESCRIPTION
- Fix publish_dir name (`report` -> `reports`)
- Update peaceiris/actions-gh-pages to v4
- Update `source` config of maven-javadoc-plugin in pom.xml to match `java-version` (11) in docs.yml
- Will fix #4
- See demo here: https://bact.github.io/spdx-java-v3jsonld-store/

----

Note that there are these 100 warnings (since before this PR, and this PR does not fix that yet):

> Warning: [WARNING] javadoc: warning - The code being documented uses modules but the packages defined in https://docs.oracle.com/javase/8/docs/api/ are in the unnamed module.

(See [Generate docs](https://github.com/spdx/spdx-java-v3jsonld-store/actions/runs/12362717762/job/34502607077) step in one of the runs)

They occure as Javadoc reports that some code use ["modules" (JPMS)](https://www.oracle.com/ie/corporate/features/understanding-java-9-modules.html) which is not yet supported in Java 8.

Changing `source` and `target` of maven-compiler-plugin in pom.xml to `9` or later will fix those warnings.