### PR TITLE
Fix publish_dir path and update gh-pages actions

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,21 +3,22 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 jobs:
   docs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
-    - uses: actions/setup-java@v3
+    - uses: actions/setup-java@v4
       with:
         distribution: 'temurin'
         java-version: 11
     - name: Cache Maven packages
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ~/.m2
         key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
@@ -26,7 +27,7 @@ jobs:
       run: mvn javadoc:javadoc
 
     - name: Deploy docs
-      uses: peaceiris/actions-gh-pages@v3
+      uses: peaceiris/actions-gh-pages@v4
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
-        publish_dir: ./target/report/apidocs
+        publish_dir: ./target/reports/apidocs

--- a/pom.xml
+++ b/pom.xml
@@ -106,6 +106,12 @@
 									<goal>jar</goal>
 								</goals>
 							</execution>
+							<execution>
+								<goals>
+									<goal>javadoc</goal>
+									<goal>generatePackageList</goal>
+								</goals>
+                    		</execution>
 						</executions>
 					</plugin>
 					<plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -91,6 +91,10 @@
 							<quiet>true</quiet>
 							<notimestamp>true</notimestamp>
 							<doclint>all,-missing</doclint>
+							<links>
+								<link>https://spdx.github.io/spdx-java-core/</link>
+								<link>https://spdx.github.io/Spdx-Java-Library/</link>
+							</links>
 						</configuration>
 						<executions>
 							<execution>

--- a/pom.xml
+++ b/pom.xml
@@ -87,6 +87,7 @@
 						<artifactId>maven-javadoc-plugin</artifactId>
 						<version>3.5.0</version>
 						<configuration>
+							<source>9</source>
 							<quiet>true</quiet>
 							<notimestamp>true</notimestamp>
 							<doclint>all,-missing</doclint>
@@ -243,8 +244,8 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>3.11.0</version>
 				<configuration>
-					<source>1.8</source>
-					<target>1.8</target>
+					<source>9</source>
+					<target>9</target>
 					<encoding>${project.build.sourceEncoding}</encoding>
 					<showDeprecation>true</showDeprecation>
 					<showWarnings>true</showWarnings>

--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,7 @@
 						<artifactId>maven-javadoc-plugin</artifactId>
 						<version>3.5.0</version>
 						<configuration>
-							<source>9</source>
+							<source>11</source>
 							<quiet>true</quiet>
 							<notimestamp>true</notimestamp>
 							<doclint>all,-missing</doclint>

--- a/pom.xml
+++ b/pom.xml
@@ -244,8 +244,8 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>3.11.0</version>
 				<configuration>
-					<source>9</source>
-					<target>9</target>
+					<source>11</source>
+					<target>11</target>
 					<encoding>${project.build.sourceEncoding}</encoding>
 					<showDeprecation>true</showDeprecation>
 					<showWarnings>true</showWarnings>

--- a/pom.xml
+++ b/pom.xml
@@ -95,6 +95,7 @@
 								<link>https://spdx.github.io/spdx-java-core/</link>
 								<link>https://spdx.github.io/Spdx-Java-Library/</link>
 							</links>
+							<detectLinks>true</detectLinks>
 						</configuration>
 						<executions>
 							<execution>
@@ -106,12 +107,6 @@
 									<goal>jar</goal>
 								</goals>
 							</execution>
-							<execution>
-								<goals>
-									<goal>javadoc</goal>
-									<goal>generatePackageList</goal>
-								</goals>
-                    		</execution>
 						</executions>
 					</plugin>
 					<plugin>

--- a/src/main/java/org/spdx/v3jsonldstore/JsonLDDeserializer.java
+++ b/src/main/java/org/spdx/v3jsonldstore/JsonLDDeserializer.java
@@ -41,7 +41,6 @@ import net.jimblackler.jsonschemafriend.GenerationException;
  * Class to manage deserializing SPDX 3.X JSON-LD
  * 
  * @author Gary O'Neall
- *
  */
 public class JsonLDDeserializer {
 	

--- a/src/main/java/org/spdx/v3jsonldstore/JsonLDSchema.java
+++ b/src/main/java/org/spdx/v3jsonldstore/JsonLDSchema.java
@@ -38,10 +38,9 @@ import net.jimblackler.jsonschemafriend.SchemaStore;
 import net.jimblackler.jsonschemafriend.Validator;
 
 /**
- * @author Gary O'Neall
- * 
  * Represents the JSON Schema for SPDX 3.X includes a number of convenience methods
  *
+ * @author Gary O'Neall
  */
 @SuppressWarnings("LoggingSimilarMessage")
 public class JsonLDSchema {

--- a/src/main/java/org/spdx/v3jsonldstore/JsonLDSerializer.java
+++ b/src/main/java/org/spdx/v3jsonldstore/JsonLDSerializer.java
@@ -50,15 +50,14 @@ import com.fasterxml.jackson.databind.node.TextNode;
 import net.jimblackler.jsonschemafriend.GenerationException;
 
 /**
- * @author Gary O'Neall
- * <p>
  * Serializer to serialize a model store containing SPDX Spec version 3 elements
  * <p>
  * The <code>serialize()</code> method will serialize the <code>@graph</code> for all SPDX elements
  * stored in the model store.
  * 
- * The <code>serialize(SpdxElement element)</code> will serialize a single element
+ * The <code>serialize(SpdxElement element)</code> will serialize a single element.
  * 
+ * @author Gary O'Neall
  */
 @SuppressWarnings("LoggingSimilarMessage")
 public class JsonLDSerializer {

--- a/src/main/java/org/spdx/v3jsonldstore/JsonLDStore.java
+++ b/src/main/java/org/spdx/v3jsonldstore/JsonLDStore.java
@@ -35,10 +35,9 @@ import com.fasterxml.jackson.databind.SerializationFeature;
 import net.jimblackler.jsonschemafriend.GenerationException;
 
 /**
- * @author Gary O'Neall
- * 
  * Serializable store which reads and writes the SPDX Spec version 3 JSON LD format
  *
+ * @author Gary O'Neall
  */
 public class JsonLDStore extends ExtendedSpdxStore
 		implements

--- a/src/test/java/org/spdx/v3jsonldstore/JsonLDDeserializerTest.java
+++ b/src/test/java/org/spdx/v3jsonldstore/JsonLDDeserializerTest.java
@@ -43,7 +43,6 @@ import net.jimblackler.jsonschemafriend.GenerationException;
 
 /**
  * @author Gary O'Neall
- *
  */
 public class JsonLDDeserializerTest {
 

--- a/src/test/java/org/spdx/v3jsonldstore/JsonLDSchemaTest.java
+++ b/src/test/java/org/spdx/v3jsonldstore/JsonLDSchemaTest.java
@@ -24,8 +24,7 @@ import net.jimblackler.jsonschemafriend.GenerationException;
 import net.jimblackler.jsonschemafriend.Schema;
 
 /**
- * @author gary
- *
+ * @author Gary O'Neall
  */
 public class JsonLDSchemaTest {
 	

--- a/src/test/java/org/spdx/v3jsonldstore/JsonLDSerializerTest.java
+++ b/src/test/java/org/spdx/v3jsonldstore/JsonLDSerializerTest.java
@@ -37,8 +37,7 @@ import com.fasterxml.jackson.databind.SerializationFeature;
 import net.jimblackler.jsonschemafriend.GenerationException;
 
 /**
- * @author gary
- *
+ * @author Gary O'Neall
  */
 public class JsonLDSerializerTest {
 	ObjectMapper mapper;

--- a/src/test/java/org/spdx/v3jsonldstore/JsonLDStoreTest.java
+++ b/src/test/java/org/spdx/v3jsonldstore/JsonLDStoreTest.java
@@ -41,8 +41,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 
 /**
- * @author gary
- *
+ * @author Gary O'Neall
  */
 public class JsonLDStoreTest {
 	


### PR DESCRIPTION
What this PR does:

### Fix publish CI
- Fix publish_dir path (`report` -> `reports`) - this will fix #4
- Update peaceiris/actions-gh-pages to v4
- Fix "unnamed module" warnings by update `source` and `target` of maven-compiler-plugin in pom.xml to `11` (Java 11)
  - > Warning: [WARNING] javadoc: warning - The code being documented uses modules but the packages defined in https://docs.oracle.com/javase/8/docs/api/ are in the unnamed module. 
  - See warnings in "Generate docs" step in [a run](https://github.com/spdx/spdx-java-v3jsonld-store/actions/runs/12362717762/job/34502607077) 
  - Module ([JPMS](https://www.oracle.com/ie/corporate/features/understanding-java-9-modules.html)) was introduced in Java 9. Pick Java 11 (LTS) as Java 9 and 10 supports already ended since Sep 2018 and there are few dependency issues during Javadoc build
  - Update `source` of maven-javadoc-plugin to `11` to match `java-version` in `actions/setup-java@v4`

### Fix Javadoc comments
- Reorder info in Javadoc comments, so the class description can be correctly displayed on the API doc (descriptions of JsonLDSchema, JsonLDSerializer, and JsonLDStore were previously not picked up by Javadoc because `@author` precedes the description)

See demo at: https://bact.github.io/spdx-java-v3jsonld-store/