### PR TITLE
Add Automatic-Module-Name and more Javadoc description

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 
   <name>spdx-v3jsonld-store</name>
   <url>http://spdx.org</url>
-<description>Store for SPDX spec version 3 supporting the JSON-LD serialization format.</description>
+  <description>Store for SPDX spec version 3 supporting the JSON-LD serialization format.</description>
   <scm>
   	<url>https://github.com/spdx/spdx-java-v3jsonld-store</url>
   	<connection>scm:git:ssh://git@github.com:spdx/spdx-java-v3jsonld-store</connection>
@@ -82,6 +82,18 @@
 				        </execution>
 				      </executions>
 				    </plugin>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-jar-plugin</artifactId>
+						<version>3.4.2</version>
+						<configuration>
+						<archive>
+							<manifestEntries>
+							<Automatic-Module-Name>org.spdx.v3jsonldstore</Automatic-Module-Name>
+							</manifestEntries>
+						</archive>
+						</configuration>
+					</plugin>
 					<plugin>
 						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-javadoc-plugin</artifactId>

--- a/src/main/java/org/spdx/v3jsonldstore/JsonLDDeserializer.java
+++ b/src/main/java/org/spdx/v3jsonldstore/JsonLDDeserializer.java
@@ -1,6 +1,7 @@
 /**
+ * SPDX-FileCopyrightText: Copyright (c) 2024 Source Auditor Inc.
+ * SPDX-FileType: SOURCE
  * SPDX-License-Identifier: Apache-2.0
- * Copyright (c) 2024 Source Auditor Inc.
  */
 package org.spdx.v3jsonldstore;
 

--- a/src/main/java/org/spdx/v3jsonldstore/JsonLDSchema.java
+++ b/src/main/java/org/spdx/v3jsonldstore/JsonLDSchema.java
@@ -1,6 +1,7 @@
 /**
+ * SPDX-FileCopyrightText: Copyright (c) 2024 Source Auditor Inc.
+ * SPDX-FileType: SOURCE
  * SPDX-License-Identifier: Apache-2.0
- * Copyright (c) 2024 Source Auditor Inc.
  */
 package org.spdx.v3jsonldstore;
 

--- a/src/main/java/org/spdx/v3jsonldstore/JsonLDSerializer.java
+++ b/src/main/java/org/spdx/v3jsonldstore/JsonLDSerializer.java
@@ -1,6 +1,7 @@
 /**
+ * SPDX-FileCopyrightText: Copyright (c) 2024 Source Auditor Inc.
+ * SPDX-FileType: SOURCE
  * SPDX-License-Identifier: Apache-2.0
- * Copyright (c) 2024 Source Auditor Inc.
  */
 package org.spdx.v3jsonldstore;
 
@@ -154,12 +155,14 @@ public class JsonLDSerializer {
 	private final boolean useExternalListedElements;
 
 	/**
+	 * Serializer to serialize a model store containing SPDX 3 elements
+	 *
 	 * @param jsonMapper mapper to use for serialization
 	 * @param pretty true if the format is to be more verbose
 	 * @param useExternalListedElements if true, don't serialize any listed licenses or exceptions - treat them as external 
 	 * @param specVersion SemVer representation of the SPDX spec version
 	 * @param modelStore store where the SPDX elements are stored
-	 * @throws GenerationException  if the JSON schema is not found or is not valid
+	 * @throws GenerationException if the JSON schema is not found or is not valid
 	 */
 	public JsonLDSerializer(ObjectMapper jsonMapper, boolean pretty, boolean useExternalListedElements, String specVersion,
 			IModelStore modelStore) throws GenerationException {
@@ -196,11 +199,16 @@ public class JsonLDSerializer {
 	}
 
 	/**
-	 * Serialize SPDX document metadata and ALL elements listed in the root + all elements listed in the elements list
-	 * all references to SPDX elements not in the root or elements lists will be external
+	 * Serialize SPDX document metadata and ALL elements listed in the root + all
+	 * elements listed in the elements list
+	 *
+	 * All references to SPDX elements not in the root or elements lists will be
+	 * external.
+	 * 
 	 * @param spdxDocument SPDX document to utilize
 	 * @return the root node of the JSON serialization
-	 * @throws InvalidSPDXAnalysisException on errors retrieving the information for serialization
+	 * @throws InvalidSPDXAnalysisException on errors retrieving the information for
+	 *                                      serialization
 	 */
 	private JsonNode serializeSpdxDocument(SpdxDocument spdxDocument) throws InvalidSPDXAnalysisException {
 		ObjectNode root = jsonMapper.createObjectNode();
@@ -261,6 +269,7 @@ public class JsonLDSerializer {
 
 	/**
 	 * Serialize on the required portions of the SPDX document
+	 *
 	 * @param spdxDocument SPDX document to serialize
 	 * @param serializedId ID used in the serialization
 	 * @param idToSerializedId partial Map of IDs in the modelStore to the IDs used in the serialization
@@ -299,7 +308,9 @@ public class JsonLDSerializer {
 	}
 
 	/**
-	 * Serializes a single SPDX element - all references to other elements will be external element references
+	 * Serializes a single SPDX element - all references to other elements will be
+	 * external element references
+	 *
 	 * @param objectToSerialize object to serialize
 	 * @return the root of the serialized form of the objectToSerialize
 	 * @throws InvalidSPDXAnalysisException on SPDX parsing errors
@@ -334,6 +345,7 @@ public class JsonLDSerializer {
 
 	/**
 	 * Serialize all the objects stored in the model store
+	 *
 	 * @return the root node of the JSON serialization
 	 * @throws InvalidSPDXAnalysisException on errors retrieving the information for serialization
 	 */
@@ -385,6 +397,8 @@ public class JsonLDSerializer {
 	}
 
 	/**
+     * Converts a model object to a JSON node representation
+	 *
 	 * @param modelObject model object to serialize
 	 * @param serializedId ID used in the serialization
 	 * @param idToSerializedId partial Map of IDs in the modelStore to the IDs used in the serialization
@@ -417,7 +431,7 @@ public class JsonLDSerializer {
 
 	/**
 	 * @param prop property
-	 * @return JSON LD property name per the SPDX 3.X JSON LD spec
+	 * @return JSON-LD property name per the SPDX 3.X JSON-LD spec
 	 */
 	private String propertyToJsonLdPropName(PropertyDescriptor prop) {
 		String profile = prop.getNameSpace().substring(0, prop.getNameSpace().length()-1);
@@ -430,6 +444,8 @@ public class JsonLDSerializer {
 	}
 
 	/**
+	 * Converts an object to a JSON node representation based on the SPDX 3.X schema
+	 *
 	 * @param object object to translate to a JSON node
 	 * @param fromModelStore modelStore to retrieve the property information from
 	 * @param idToSerializedId partial Map of IDs in the modelStore to the IDs used in the serialization
@@ -461,6 +477,8 @@ public class JsonLDSerializer {
 	}
 
 	/**
+	 * Converts a typed value to a JSON node representation based on the SPDX 3.X schema
+	 *
 	 * @param tv typed value to translate to a JSON node
 	 * @param fromModelStore modelStore to retrieve the property information from
 	 * @param idToSerializedId partial Map of IDs in the modelStore to the IDs used in the serialization
@@ -481,8 +499,11 @@ public class JsonLDSerializer {
 			return inlinedJsonNode(tv, fromModelStore, idToSerializedId);
 		}
 	}
-	
+
 	/**
+	 * Converts a typed value object with inlined property values to a JSON node
+	 * representation
+	 *
 	 * @param tv typed value to translate to a JSON node
 	 * @param fromModelStore modelStore to retrieve the property information from
 	 * @param idToSerializedId partial Map of IDs in the modelStore to the IDs used in the serialization
@@ -512,6 +533,8 @@ public class JsonLDSerializer {
 	}
 
 	/**
+	 * Converts a model type to its JSON representation
+	 *
 	 * @param type model type
 	 * @return the JSON representation of the type
 	 */
@@ -525,7 +548,9 @@ public class JsonLDSerializer {
 	}
 
 	/**
-	 * @return JSON LD Schema
+	 * Returns the JSON-LD schema used for serialization
+	 *
+	 * @return JSON-LD Schema
 	 */
 	public JsonLDSchema getSchema() {
 		return this.jsonLDSchema;

--- a/src/main/java/org/spdx/v3jsonldstore/JsonLDStore.java
+++ b/src/main/java/org/spdx/v3jsonldstore/JsonLDStore.java
@@ -1,6 +1,7 @@
 /**
+ * SPDX-FileCopyrightText: Copyright (c) 2024 Source Auditor Inc.
+ * SPDX-FileType: SOURCE
  * SPDX-License-Identifier: Apache-2.0
- * Copyright (c) 2024 Source Auditor Inc.
  */
 package org.spdx.v3jsonldstore;
 
@@ -48,29 +49,38 @@ public class JsonLDStore extends ExtendedSpdxStore
 	private boolean useExternalListedElements = false;
 	
 	/**
+	 * Constructs a JsonLDStore with the specified base store and pretty format
+	 * option
+	 *
 	 * @param baseStore underlying store to use
-	 * @param pretty if true, use less compact prettier JSON LD format on output
+	 * @param pretty    if true, use less compact prettier JSON LD format on output
 	 */
 	public JsonLDStore(IModelStore baseStore, boolean pretty) {
 		super(baseStore);
 		this.pretty = pretty;
 	}
-	
+
 	/**
+	 * Constructs a JsonLDStore with the specified base store
+	 *
 	 * @param baseStore underlying store to use
 	 */
 	public JsonLDStore(IModelStore baseStore) {
 		this(baseStore, true);
 	}
-	
+
 	/**
+	 * Check the pretty format option for JSON LD output
+	 *
 	 * @return if true, use less compact prettier JSON LD format on output
 	 */
 	public boolean getPretty() {
 		return this.pretty;
 	}
-	
+
 	/**
+	 * Sets the pretty format option for JSON LD output
+	 *
 	 * @param pretty if true, use less compact prettier JSON LD format on output
 	 */
 	public void setPretty(boolean pretty) {
@@ -82,7 +92,7 @@ public class JsonLDStore extends ExtendedSpdxStore
 			throws InvalidSPDXAnalysisException, IOException {
 		serialize(stream, null);
 	}
-	
+
 	@Override 
 	public void serialize(OutputStream stream, @Nullable CoreModelObject objectToSerialize)
 			throws InvalidSPDXAnalysisException, IOException {
@@ -148,6 +158,8 @@ public class JsonLDStore extends ExtendedSpdxStore
 
 
 	/**
+	 * Converts a list of elements from a serialized graph into an SPDX document
+	 *
 	 * @param graphElements elements found in the serialized graph
 	 * @return an SPDX document representing the serialization
 	 * @throws InvalidSPDXAnalysisException on SPDX parsing errors
@@ -205,7 +217,9 @@ public class JsonLDStore extends ExtendedSpdxStore
 	}
 
 	/**
-	 * Searches for any external elements referenced in the model object and adds that to the referencedExternalElementUris
+	 * Searches for any external elements referenced in the model object and adds
+	 * that to the referencedExternalElementUris
+	 *
 	 * @param modelObject modelObject to search for external references
 	 * @param referencedExternalElementUris referenced external element URIs
 	 * @param alreadySearched set of URIs which have already been searched
@@ -231,8 +245,12 @@ public class JsonLDStore extends ExtendedSpdxStore
 	}
 
 	/**
+	 * Retrieves the URIs of any SPDX elements that already exist in the base model
+	 * store
+	 *
 	 * @param root root of a graph containing SPDX elements
-	 * @return a list of any SPDX Element URI's that already exist in the base model store
+	 * @return a list of any SPDX Element URI's that already exist in the base model
+	 *         store
 	 */
 	private List<String> getExistingElementUris(JsonNode root) {
 		List<String> retval = new ArrayList<>();
@@ -257,7 +275,10 @@ public class JsonLDStore extends ExtendedSpdxStore
 	}
 
 	/**
-	 * @param useExternalListedElements if true, don't serialize any listed licenses or exceptions - treat them as external
+	 * Sets whether to use external listed elements
+	 *
+	 * @param useExternalListedElements if true, don't serialize any listed licenses
+	 *                                  or exceptions - treat them as external
 	 */
 	public void setUseExternalListedElements(boolean useExternalListedElements) {
 		this.useExternalListedElements  = useExternalListedElements;

--- a/src/test/java/org/spdx/v3jsonldstore/JsonLDDeserializerTest.java
+++ b/src/test/java/org/spdx/v3jsonldstore/JsonLDDeserializerTest.java
@@ -1,6 +1,7 @@
 /**
+ * SPDX-FileCopyrightText: Copyright (c) 2024 Source Auditor Inc.
+ * SPDX-FileType: SOURCE
  * SPDX-License-Identifier: Apache-2.0
- * Copyright (c) 2024 Source Auditor Inc.
  */
 package org.spdx.v3jsonldstore;
 

--- a/src/test/java/org/spdx/v3jsonldstore/JsonLDSchemaTest.java
+++ b/src/test/java/org/spdx/v3jsonldstore/JsonLDSchemaTest.java
@@ -1,6 +1,7 @@
 /**
+ * SPDX-FileCopyrightText: Copyright (c) 2024 Source Auditor Inc.
+ * SPDX-FileType: SOURCE
  * SPDX-License-Identifier: Apache-2.0
- * Copyright (c) 2024 Source Auditor Inc.
  */
 package org.spdx.v3jsonldstore;
 

--- a/src/test/java/org/spdx/v3jsonldstore/JsonLDSerializerTest.java
+++ b/src/test/java/org/spdx/v3jsonldstore/JsonLDSerializerTest.java
@@ -1,6 +1,7 @@
 /**
+ * SPDX-FileCopyrightText: Copyright (c) 2024 Source Auditor Inc.
+ * SPDX-FileType: SOURCE
  * SPDX-License-Identifier: Apache-2.0
- * Copyright (c) 2024 Source Auditor Inc.
  */
 package org.spdx.v3jsonldstore;
 

--- a/src/test/java/org/spdx/v3jsonldstore/JsonLDStoreTest.java
+++ b/src/test/java/org/spdx/v3jsonldstore/JsonLDStoreTest.java
@@ -1,6 +1,7 @@
 /**
+ * SPDX-FileCopyrightText: Copyright (c) 2024 Source Auditor Inc.
+ * SPDX-FileType: SOURCE
  * SPDX-License-Identifier: Apache-2.0
- * Copyright (c) 2024 Source Auditor Inc.
  */
 package org.spdx.v3jsonldstore;
 


### PR DESCRIPTION
- Add `<Automatic-Module-Name>org.spdx.v3jsonldstore</Automatic-Module-Name>` to pom.xml
- Add more Javadoc comments
- Add SPDX copyright header to source files