### PR TITLE
Update jsonschemafriend dependency to maven central

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,12 +57,6 @@
         <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
       </repository>
 	</distributionManagement>
-	<repositories>
-      <repository>
-        <id>jitpack.io</id>
-        <url>https://jitpack.io</url>
-      </repository>
-    </repositories>
 	<profiles>
 		<profile>
 			<id>release</id>
@@ -151,9 +145,9 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>net.jimblackler.jsonschemafriend</groupId>
-      <artifactId>core</artifactId>
-      <version>0.12.3</version>
+      <groupId>org.metaeffekt.bundle.jsonschemafriend</groupId>
+      <artifactId>ae-jsonschemafriend-core</artifactId>
+      <version>0.12.5-1</version>
     </dependency>
     <dependency>
     	<groupId>org.spdx</groupId>


### PR DESCRIPTION
Updates the dependency for jsonschemafriend to use Maven Central rather than jitpack.

Also remove the jitpack repository reference.

Fixes #18