### PR TITLE
Add creationInfo into generated SPDX Document

### DIFF
--- a/TestFiles/no_document.json
+++ b/TestFiles/no_document.json
@@ -1,0 +1,20 @@
+{
+  "@context" : "https://spdx.org/rdf/3.0.1/spdx-context.jsonld",
+  "@graph" : [ {
+    "@id" : "_:creationInfo_0",
+    "type" : "CreationInfo",
+    "specVersion" : "3.0.1",
+    "createdBy" : [ "http://prefixAgent/agent" ],
+    "created" : "2025-09-16T14:31:07Z"
+  }, {
+    "spdxId" : "http://prefixAgent/agent",
+    "type" : "Agent",
+    "name" : "agent",
+    "creationInfo" : "_:creationInfo_0"
+  }, {
+    "spdxId" : "http://prefixsbom/v0",
+    "type" : "software_Sbom",
+    "name" : "v0",
+    "creationInfo" : "_:creationInfo_0"
+  } ]
+}

--- a/src/main/java/org/spdx/v3jsonldstore/JsonLDStore.java
+++ b/src/main/java/org/spdx/v3jsonldstore/JsonLDStore.java
@@ -19,6 +19,7 @@ import org.spdx.core.InvalidSPDXAnalysisException;
 import org.spdx.core.TypedValue;
 import org.spdx.library.SpdxModelFactory;
 import org.spdx.library.model.v3_0_1.SpdxConstantsV3;
+import org.spdx.library.model.v3_0_1.SpdxModelClassFactoryV3;
 import org.spdx.library.model.v3_0_1.core.*;
 import org.spdx.storage.IModelStore;
 import org.spdx.storage.ISerializableModelStore;
@@ -177,11 +178,12 @@ public class JsonLDStore extends ExtendedSpdxStore
 						SpdxConstantsV3.CORE_SPDX_DOCUMENT, null, existingSpdxDocument.get(0).getSpecVersion(),
 						 false, null); 
 		} else {
-			
-			String documentObjectUri = "urn:spdx-document:" + UUID.randomUUID();
-			retval = (SpdxDocument)SpdxModelFactory.inflateModelObject(this, documentObjectUri,
-					SpdxConstantsV3.CORE_SPDX_DOCUMENT, null, SpdxModelFactory.getLatestSpecVersion(),
-					 true, null); 
+			String prefix = "urn:generated-spdx-document:" + UUID.randomUUID();
+			CreationInfo creationInfo = SpdxModelClassFactoryV3.createCreationInfo(
+					this, prefix + ":Agent", "SPDX JSON-LD Deserializer",
+					null);
+			creationInfo.setComment("Document created while deserializing a JSON-LD file with no Document element meta-data");
+			retval = creationInfo.createSpdxDocument(prefix + ":spdx-document").build();
 		}
 		Collection<Element> elements = retval.getElements();
 		elements.clear();


### PR DESCRIPTION
Documents are generated if no SPDX document element was found while deserializing.

Fixes #31