### PR TITLE
Update dependencies in POM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,6 +62,11 @@
 			<id>release</id>
 			<build>
 				<plugins>
+					<plugin>
+					<groupId>org.sonarsource.scanner.maven</groupId>
+					<artifactId>sonar-maven-plugin</artifactId>
+					<version>5.2.0.4988</version>
+					</plugin>
 				   	<plugin>
 				      <groupId>org.apache.maven.plugins</groupId>
 				      <artifactId>maven-source-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
 				   	<plugin>
 				      <groupId>org.apache.maven.plugins</groupId>
 				      <artifactId>maven-source-plugin</artifactId>
-				      <version>3.2.1</version>
+				      <version>3.3.1</version>
 				      <executions>
 				        <execution>
 				          <id>attach-sources</id>
@@ -91,7 +91,7 @@
 					<plugin>
 						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-javadoc-plugin</artifactId>
-						<version>3.5.0</version>
+						<version>3.11.3</version>
 						<configuration>
 							<source>11</source>
 							<quiet>true</quiet>
@@ -118,7 +118,7 @@
 					<plugin>
 		      			<groupId>org.apache.maven.plugins</groupId>
 		      			<artifactId>maven-gpg-plugin</artifactId>
-		      			<version>1.6</version>
+		      			<version>3.2.8</version>
 		      			<executions>
 		        			<execution>
 		          				<id>sign-artifacts</id>
@@ -157,27 +157,27 @@
     <dependency>
     	<groupId>com.google.code.gson</groupId>
     	<artifactId>gson</artifactId>
-    	<version>2.8.9</version>
+    	<version>2.13.2</version>
     </dependency>
     <dependency>
     	<groupId>com.fasterxml.jackson.core</groupId>
     	<artifactId>jackson-core</artifactId>
-    	<version>2.15.4</version>
+    	<version>2.20.0</version>
     </dependency>
     <dependency>
     	<groupId>com.fasterxml.jackson.core</groupId>
     	<artifactId>jackson-databind</artifactId>
-    	<version>2.16.2</version>
+    	<version>2.20.0</version>
     </dependency>
     <dependency>
     	<groupId>com.fasterxml.jackson.dataformat</groupId>
     	<artifactId>jackson-dataformat-xml</artifactId>
-    	<version>2.15.4</version>
+    	<version>2.20.0</version>
     </dependency>
     <dependency>
     	<groupId>com.fasterxml.jackson.dataformat</groupId>
     	<artifactId>jackson-dataformat-yaml</artifactId>
-    	<version>2.15.4</version>
+    	<version>2.20.0</version>
     </dependency>
 	<dependency>
 		<groupId>com.github.java-json-tools</groupId>
@@ -235,7 +235,7 @@
 			<plugin>
 		      <groupId>org.apache.maven.plugins</groupId>
 		      <artifactId>maven-release-plugin</artifactId>
-		      <version>3.0.1</version>
+		      <version>3.1.1</version>
 		      <configuration>
 		        <tagNameFormat>v@{project.version}</tagNameFormat>
 		        <releaseProfiles>release</releaseProfiles>
@@ -253,7 +253,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
-				<version>3.11.0</version>
+				<version>3.14.0</version>
 				<configuration>
 					<source>11</source>
 					<target>11</target>
@@ -266,7 +266,7 @@
 			<plugin>
 				<groupId>org.spdx</groupId>
 					<artifactId>spdx-maven-plugin</artifactId>
-					<version>1.0.2</version>
+					<version>1.0.3</version>
 					<executions>
 						<execution>
 							<id>build-spdx</id>

--- a/pom.xml
+++ b/pom.xml
@@ -62,11 +62,6 @@
 			<id>release</id>
 			<build>
 				<plugins>
-					<plugin>
-					<groupId>org.sonarsource.scanner.maven</groupId>
-					<artifactId>sonar-maven-plugin</artifactId>
-					<version>5.2.0.4988</version>
-					</plugin>
 				   	<plugin>
 				      <groupId>org.apache.maven.plugins</groupId>
 				      <artifactId>maven-source-plugin</artifactId>
@@ -196,7 +191,7 @@
     	<version>20231013</version>
     </dependency>
   </dependencies>
-     <build>
+    <build>
   		<resources>
 			<resource>
 				<targetPath>resources</targetPath>
@@ -308,7 +303,12 @@
 					</creators>
 					<originator>Organization: Linux Foundation</originator>
 				</configuration>
-	          </plugin>
+	        </plugin>
+			<plugin>
+				<groupId>org.sonarsource.scanner.maven</groupId>
+				<artifactId>sonar-maven-plugin</artifactId>
+				<version>5.2.0.4988</version>
+			</plugin>
 		</plugins>
   </build>
   <reporting>


### PR DESCRIPTION
- Update spdx-maven-plugin to 1.0.3
- Update maven-gpg-plugin to 3.2.8 (as used currently in spdx-java-core)
- Update other dependencies to latest minor version
- Add explicit sonar-maven-plugin (to address failing CI: https://github.com/spdx/spdx-java-v3jsonld-store/actions/runs/17811701670/job/50636828172?pr=32#step:6:7353)
