### PR TITLE
Ensure Sonar cache directory exists

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,6 +23,8 @@ jobs:
       with:
         distribution: 'temurin'
         java-version: 17
+    - name: Ensure Sonar cache directory exists
+      run: mkdir -p ~/.sonar/cache
     - name: Cache SonarCloud packages
       uses: actions/cache@v3
       with:


### PR DESCRIPTION
Create the cache dir if not exists.

To fix this warning: https://github.com/spdx/spdx-java-v3jsonld-store/actions/runs/17814049817/job/50643852880?pr=33#step:10:2 