### PR TITLE
Check for SPDX namespace when serializing properties

### DIFF
--- a/src/main/java/org/spdx/v3jsonldstore/JsonLDDeserializer.java
+++ b/src/main/java/org/spdx/v3jsonldstore/JsonLDDeserializer.java
@@ -425,7 +425,21 @@ public class JsonLDDeserializer {
 	private Optional<PropertyDescriptor> jsonFieldNameToProperty(String fieldName,
 																 String specVersion) throws GenerationException {
 		JsonLDSchema schema = getOrCreateSchema(specVersion);
-		return schema.getPropertyDescriptor(fieldName);
+		Optional<PropertyDescriptor> retval = schema.getPropertyDescriptor(fieldName);
+		if (retval.isPresent()) {
+			return retval;
+		}
+		// we'll assume this is a URI for an extension property
+		int lastPartIndex = fieldName.lastIndexOf('#');
+		if (lastPartIndex < 0) {
+			lastPartIndex = fieldName.lastIndexOf('/');
+		}
+		if (lastPartIndex < 0) {
+			lastPartIndex = 0;
+		}
+		return Optional.of(new PropertyDescriptor(
+				fieldName.substring(lastPartIndex+1), fieldName.substring(0, lastPartIndex+1)));
+
 	}
 
 	/**

--- a/src/main/java/org/spdx/v3jsonldstore/JsonLDSerializer.java
+++ b/src/main/java/org/spdx/v3jsonldstore/JsonLDSerializer.java
@@ -430,13 +430,21 @@ public class JsonLDSerializer {
 	 * @return JSON-LD property name per the SPDX 3.X JSON-LD spec
 	 */
 	private String propertyToJsonLdPropName(PropertyDescriptor prop) {
-		String profile = prop.getNameSpace().substring(0, prop.getNameSpace().length()-1);
-		profile = profile.substring(profile.lastIndexOf('/') + 1);
-		if ("Core".equals(profile)) {
-			return prop.getName();
+		if (prop.getNameSpace().startsWith("https://spdx.org/rdf/")) {
+			// we'll assume this is an SPDX standard property URL
+			//TODO: Add an SPDX general namespace prefix to SpdxConstantsV3 we can use for comparison
+			String profile = prop.getNameSpace().substring(0, prop.getNameSpace().length()-1);
+			profile = profile.substring(profile.lastIndexOf('/') + 1);
+			if ("Core".equals(profile)) {
+				return prop.getName();
+			} else {
+				return profile.toLowerCase() + "_" + prop.getName();
+			}
 		} else {
-			return profile.toLowerCase() + "_" + prop.getName();
+			// we'll assume this is an extension property
+			return prop.toString();
 		}
+
 	}
 
 	/**


### PR DESCRIPTION
When serializaing property extensions, the property namespace will not be prefixed by the SPDX RDF namepace.  In this case, we need to preserver the entire URI for the property.